### PR TITLE
chore: rename project to `noisegen-cpp`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,14 +16,14 @@ jobs:
         cppstd: [ 17, 20 ]
         include:
           - os: ubuntu-20.04
-            cli-path: ./build/pengencli
-            lib-path: ./build/libpengen.a
+            cli-path: ./build/noisegencli
+            lib-path: ./build/libnoisegen.a
           - os: macos-11
-            cli-path: ./build/pengencli
-            lib-path: ./build/libpengen.a
+            cli-path: ./build/noisegencli
+            lib-path: ./build/libnoisegen.a
           - os: windows-2019
-            cli-path: ./build/pengencli.exe
-            lib-path: ./build/pengen.lib
+            cli-path: ./build/noisegencli.exe
+            lib-path: ./build/noisegen.lib
             pdb-path: ./build/*.pdb
 
     runs-on: ${{ matrix.os }}
@@ -43,7 +43,7 @@ jobs:
           cd build
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.cppstd }} \
                 -DCMAKE_BUILD_TYPE=${{ matrix.mode }} \
-                -DPENGEN_WITH_PROFILER=ON ..
+                -DNOISEGEN_WITH_PROFILER=ON ..
 
       - name: Build
         working-directory: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(perlin-noise-generator)
+project(noisegen-cpp)
 
 if (NOT "${CMAKE_CXX_STANDARD}")
     set(CMAKE_CXX_STANDARD 17)
@@ -13,11 +13,11 @@ endif ()
 
 include(cmake/flags.cmake)
 
-option(PENGEN_BUILD_CLI "Build CLI" ON)
-option(PENGEN_BUILD_GUI "Build GUI" ON) # soon™️
+option(NOISEGEN_BUILD_CLI "Build CLI" ON)
+option(NOISEGEN_BUILD_GUI "Build GUI" ON) # soon™️
 
-option(PENGEN_WITH_PROFILER "Enable scoped profiler" OFF)
-# option(PENGEN_BUILD_SHARED_LIB "Build Shared Library" ON) # TODO: implement this
+option(NOISEGEN_WITH_PROFILER "Enable scoped profiler" OFF)
+# option(NOISEGEN_BUILD_SHARED_LIB "Build Shared Library" ON) # TODO: implement this
 
 if (WIN32 OR WIN64)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/")
@@ -35,6 +35,6 @@ endif ()
 add_subdirectory(lib)
 include_directories(lib/include)
 
-if (${PENGEN_BUILD_CLI})
+if (${NOISEGEN_BUILD_CLI})
     add_subdirectory(cli)
 endif ()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# noisegen
+# noisegen-cpp
 ###### Cross-Platform Perlin Noise Generator written in C++, just for fun :)
 
 ### Supported platforms

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# perlin-noise-generator
+# noisegen
 ###### Cross-Platform Perlin Noise Generator written in C++, just for fun :)
 
 ### Supported platforms

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(
-        pengencli
+        noisegencli
         src/Main.cpp
 )
-target_link_libraries(pengencli PUBLIC pengen)
-target_include_directories(pengencli SYSTEM PUBLIC ${PROJECT_SOURCE_DIR}/vendor/argparse/include)
+target_link_libraries(noisegencli PUBLIC noisegen)
+target_include_directories(noisegencli SYSTEM PUBLIC ${PROJECT_SOURCE_DIR}/vendor/argparse/include)

--- a/cli/src/Main.cpp
+++ b/cli/src/Main.cpp
@@ -17,16 +17,16 @@
 #include <CImg.h>
 #include <argparse/argparse.hpp>
 
-#include "perlin-noise-generator/Generator.hpp"
-#include "perlin-noise-generator/Settings.hpp"
-#include "perlin-noise-generator/ScopedProfiler.hpp"
-#include "perlin-noise-generator/Exception.hpp"
+#include <noisegen/Generator.hpp>
+#include <noisegen/Settings.hpp>
+#include <noisegen/ScopedProfiler.hpp>
+#include <noisegen/Exception.hpp>
 
-static pengen::Settings parseArguments(int argc, const char *const *const argv)
+static noisegen::Settings parseArguments(int argc, const char *const *const argv)
 {
-    PENGEN_SCOPED_PROFILER("parseArguments()");
+    NOISEGEN_SCOPED_PROFILER("parseArguments()");
 
-    pengen::Settings settings{};
+    noisegen::Settings settings{};
 
     // constexpr auto strToInt = [](const std::string &value) { return std::stoi(value); };
     constexpr auto strToUInt32 = [](const std::string &value) { return static_cast<uint32_t>(std::stoul(value)); };
@@ -80,12 +80,12 @@ static pengen::Settings parseArguments(int argc, const char *const *const argv)
     {
         std::cerr << program;
         std::cerr << "\nerror: " << e.what() << '\n';
-        throw pengen::ArgumentParseException{};
+        throw noisegen::ArgumentParseException{};
     } catch (const std::invalid_argument &e)
     {
         std::cerr << program;
         std::cerr << "\nerror: invalid argument: " << e.what() << '\n';
-        throw pengen::ArgumentParseException{};
+        throw noisegen::ArgumentParseException{};
     }
 
     settings.width = program.get<uint32_t>("width");
@@ -102,19 +102,19 @@ static pengen::Settings parseArguments(int argc, const char *const *const argv)
 
 int main(int argc, const char *const *const argv)
 {
-    PENGEN_SCOPED_PROFILER("main()");
+    NOISEGEN_SCOPED_PROFILER("main()");
 
-    pengen::Settings settings;
+    noisegen::Settings settings;
 
     try
     {
         settings = parseArguments(argc, argv);
-    } catch (const pengen::ArgumentParseException &)
+    } catch (const noisegen::ArgumentParseException &)
     {
         return 1;
     }
 
-    pengen::Generator generator{settings};
+    noisegen::Generator generator{settings};
 
     generator.generate();
     generator.saveToPGM();

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -11,9 +11,9 @@ if (MSVC)
 endif ()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_definitions(PENGEN_HAS_EXEC_POLICIES=0)
+    add_compile_definitions(NOISEGEN_HAS_EXEC_POLICIES=0)
 else ()
-    add_compile_definitions(PENGEN_HAS_EXEC_POLICIES=1)
+    add_compile_definitions(NOISEGEN_HAS_EXEC_POLICIES=1)
 endif ()
 
 if (${CMAKE_BUILD_TYPE} MATCHES "Debug")
@@ -22,10 +22,10 @@ else ()
     add_compile_definitions(RELEASE=1)
 endif ()
 
-if (${PENGEN_WITH_PROFILER})
-    add_compile_definitions(PENGEN_WITH_PROFILER=1)
+if (${NOISEGEN_WITH_PROFILER})
+    add_compile_definitions(NOISEGEN_WITH_PROFILER=1)
 else ()
-    add_compile_definitions(PENGEN_WITH_PROFILER=0)
+    add_compile_definitions(NOISEGEN_WITH_PROFILER=0)
 endif ()
 
 add_compile_definitions(cimg_display=0) # Won't need to display anything through CImg

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_library(
-        pengen
-        src/Generator.cpp include/perlin-noise-generator/Generator.hpp
-        src/Random.cpp include/perlin-noise-generator/Random.hpp
-        src/Settings.cpp include/perlin-noise-generator/Settings.hpp
-        src/ScopedProfiler.cpp include/perlin-noise-generator/ScopedProfiler.hpp
-        src/Exception.cpp include/perlin-noise-generator/Exception.hpp
+        noisegen
+        src/Generator.cpp include/noisegen/Generator.hpp
+        src/Random.cpp include/noisegen/Random.hpp
+        src/Settings.cpp include/noisegen/Settings.hpp
+        src/ScopedProfiler.cpp include/noisegen/ScopedProfiler.hpp
+        src/Exception.cpp include/noisegen/Exception.hpp
 )
-target_include_directories(pengen PRIVATE include/perlin-noise-generator)
-target_include_directories(pengen SYSTEM PUBLIC ${PROJECT_SOURCE_DIR}/vendor/CImg)
+target_include_directories(noisegen PRIVATE include/noisegen)
+target_include_directories(noisegen SYSTEM PUBLIC ${PROJECT_SOURCE_DIR}/vendor/CImg)

--- a/lib/include/noisegen/Exception.hpp
+++ b/lib/include/noisegen/Exception.hpp
@@ -23,7 +23,7 @@
 #include <string>
 #include <string_view>
 
-namespace pengen {
+namespace noisegen {
 class Exception : public std::exception
 {
 public:
@@ -37,7 +37,7 @@ public:
     [[nodiscard]] const char *what() const noexcept override;
 
 protected:
-    std::string m_what{"pengen exception"};
+    std::string m_what{"noisegen exception"};
 };
 
 class ArgumentParseException : public Exception
@@ -48,4 +48,4 @@ public:
     explicit ArgumentParseException(std::string_view what);
     explicit ArgumentParseException(std::string what);
 };
-}  // namespace pengen
+}  // namespace noisegen

--- a/lib/include/noisegen/Generator.hpp
+++ b/lib/include/noisegen/Generator.hpp
@@ -35,7 +35,7 @@
  * Original implementation: https://mrl.cs.nyu.edu/~perlin/noise/
  */
 
-namespace pengen {
+namespace noisegen {
 struct Pixel
 {
     uint32_t x{};
@@ -87,7 +87,7 @@ public:
     template<typename Gen>
     void shufflePermutationArray(Gen &&generator)
     {
-        PENGEN_SCOPED_PROFILER("Generator::shufflePermutationArray()");
+        NOISEGEN_SCOPED_PROFILER("Generator::shufflePermutationArray()");
 
         std::shuffle(m_permutations.begin(), m_permutations.end(), std::forward<Gen>(generator));
     }
@@ -131,4 +131,4 @@ private:
         return ((h & 1) == 0 ? u : -u) + ((h & 2) == 0 ? v : -v);
     }
 };
-}  // namespace pengen
+}  // namespace noisegen

--- a/lib/include/noisegen/Random.hpp
+++ b/lib/include/noisegen/Random.hpp
@@ -21,7 +21,7 @@
 
 #include <random>
 
-namespace pengen {
+namespace noisegen {
 struct Random final
 {
     Random() = delete;
@@ -29,4 +29,4 @@ struct Random final
     static std::random_device s_randomDevice;
     static std::mt19937 s_generator;
 };
-}  // namespace pengen
+}  // namespace noisegen

--- a/lib/include/noisegen/ScopedProfiler.hpp
+++ b/lib/include/noisegen/ScopedProfiler.hpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <utility>
 
-namespace pengen::utils {
+namespace noisegen::utils {
 class ScopedProfiler final
 {
 public:
@@ -46,15 +46,15 @@ public:
     ScopedProfiler &operator=(ScopedProfiler &&) = delete;
     ScopedProfiler &operator=(const ScopedProfiler &) = delete;
 };
-}  // namespace pengen::utils
+}  // namespace noisegen::utils
 
-#if PENGEN_WITH_PROFILER
-    #define PENGEN_SCOPED_PROFILER_COMB1(x, y) x##y
-    #define PENGEN_SCOPED_PROFILER_COMB(x, y)  PENGEN_SCOPED_PROFILER_COMB1(x, y)
+#if NOISEGEN_WITH_PROFILER
+    #define NOISEGEN_SCOPED_PROFILER_COMB1(x, y) x##y
+    #define NOISEGEN_SCOPED_PROFILER_COMB(x, y)  NOISEGEN_SCOPED_PROFILER_COMB1(x, y)
 
-    #define PENGEN_SCOPED_PROFILER(x) \
-        const pengen::utils::ScopedProfiler PENGEN_SCOPED_PROFILER_COMB(PENGEN_SCOPED_PROFILER_, __LINE__)(x)
+    #define NOISEGEN_SCOPED_PROFILER(x) \
+        const noisegen::utils::ScopedProfiler NOISEGEN_SCOPED_PROFILER_COMB(NOISEGEN_SCOPED_PROFILER_, __LINE__)(x)
 #else
-    #define PENGEN_SCOPED_PROFILER(x)     (void) 0
-    #define PENGEN_SCOPED_PROFILER_DTOR() (void) 0
+    #define NOISEGEN_SCOPED_PROFILER(x)     (void) 0
+    #define NOISEGEN_SCOPED_PROFILER_DTOR() (void) 0
 #endif

--- a/lib/include/noisegen/Settings.hpp
+++ b/lib/include/noisegen/Settings.hpp
@@ -22,7 +22,7 @@
 #include <cstdint>
 #include <ostream>
 
-namespace pengen {
+namespace noisegen {
 struct Settings
 {
     uint32_t width{};
@@ -42,5 +42,5 @@ struct Settings
     [[nodiscard]] std::string toString() const;
 };
 
-std::ostream &operator<<(std::ostream &os, const pengen::Settings &settings);
-}  // namespace pengen
+std::ostream &operator<<(std::ostream &os, const noisegen::Settings &settings);
+}  // namespace noisegen

--- a/lib/src/Exception.cpp
+++ b/lib/src/Exception.cpp
@@ -19,31 +19,31 @@
 
 #include "Exception.hpp"
 
-pengen::Exception::Exception(const char *what) : m_what{what}
+noisegen::Exception::Exception(const char *what) : m_what{what}
 {
 }
 
-pengen::Exception::Exception(std::string_view what) : m_what{what}
+noisegen::Exception::Exception(std::string_view what) : m_what{what}
 {
 }
 
-pengen::Exception::Exception(std::string what) : m_what{std::move(what)}
+noisegen::Exception::Exception(std::string what) : m_what{std::move(what)}
 {
 }
 
-const char *pengen::Exception::what() const noexcept
+const char *noisegen::Exception::what() const noexcept
 {
     return m_what.c_str();
 }
 
-pengen::ArgumentParseException::ArgumentParseException(const char *what) : Exception(what)
+noisegen::ArgumentParseException::ArgumentParseException(const char *what) : Exception(what)
 {
 }
 
-pengen::ArgumentParseException::ArgumentParseException(std::string_view what) : Exception(what)
+noisegen::ArgumentParseException::ArgumentParseException(std::string_view what) : Exception(what)
 {
 }
 
-pengen::ArgumentParseException::ArgumentParseException(std::string what) : Exception(std::move(what))
+noisegen::ArgumentParseException::ArgumentParseException(std::string what) : Exception(std::move(what))
 {
 }

--- a/lib/src/Generator.cpp
+++ b/lib/src/Generator.cpp
@@ -14,11 +14,11 @@
 **   limitations under the License.
 */
 
-#if PENGEN_HAS_EXEC_POLICIES
+#if NOISEGEN_HAS_EXEC_POLICIES
     #include <execution>
-    #define PENGEN_EXEC_PAR_UNSEC std::execution::par_unseq,
+    #define NOISEGEN_EXEC_PAR_UNSEC std::execution::par_unseq,
 #else
-    #define PENGEN_EXEC_PAR_UNSEC
+    #define NOISEGEN_EXEC_PAR_UNSEC
 #endif
 
 #include <limits>
@@ -36,10 +36,10 @@
  * Original implementation: https://mrl.cs.nyu.edu/~perlin/noise/
  */
 
-pengen::Generator::Generator(Settings settings, const std::optional<PermutationArray> &permutationArrayOverride)
+noisegen::Generator::Generator(Settings settings, const std::optional<PermutationArray> &permutationArrayOverride)
     : m_settings{std::move(settings)}
 {
-    PENGEN_SCOPED_PROFILER("Generator()");
+    NOISEGEN_SCOPED_PROFILER("Generator()");
 
     if (permutationArrayOverride.has_value())
         m_permutations = permutationArrayOverride.value();
@@ -49,7 +49,7 @@ pengen::Generator::Generator(Settings settings, const std::optional<PermutationA
     cacheFrequencyAndAmplitude();
 }
 
-double pengen::Generator::noise3D(double x, double y, double z) const noexcept
+double noisegen::Generator::noise3D(double x, double y, double z) const noexcept
 {
     auto X = static_cast<uint8_t>(static_cast<int>(std::floor(x)) & 255);
     auto Y = static_cast<uint8_t>(static_cast<int>(std::floor(y)) & 255);
@@ -78,9 +78,9 @@ double pengen::Generator::noise3D(double x, double y, double z) const noexcept
            lerp(u, grad(getPermutation(AB + 1), x, y - 1, z - 1), grad(getPermutation(BB + 1), x - 1, y - 1, z - 1))));
 }
 
-void pengen::Generator::generate()
+void noisegen::Generator::generate()
 {
-    PENGEN_SCOPED_PROFILER("Generator::generate()");
+    NOISEGEN_SCOPED_PROFILER("Generator::generate()");
 
     // keep track of min and max value for scaling later
     m_minNoiseValue = std::numeric_limits<double>::max();
@@ -94,7 +94,7 @@ void pengen::Generator::generate()
         for (uint32_t x = 0; x < m_settings.width; x++)
             m_pixels.emplace_back(x, y);
 
-    std::transform(PENGEN_EXEC_PAR_UNSEC m_pixels.cbegin(), m_pixels.cend(), m_pixels.begin(), [&](auto &&pixel) {
+    std::transform(NOISEGEN_EXEC_PAR_UNSEC m_pixels.cbegin(), m_pixels.cend(), m_pixels.begin(), [&](auto &&pixel) {
         const auto x = pixel.x;
         const auto y = pixel.y;
         double noiseValue = 0.0;
@@ -115,9 +115,9 @@ void pengen::Generator::generate()
     m_maxNoiseValue = max->value;
 }
 
-void pengen::Generator::saveToPGM() const
+void noisegen::Generator::saveToPGM() const
 {
-    PENGEN_SCOPED_PROFILER("Generator::saveToPGM()");
+    NOISEGEN_SCOPED_PROFILER("Generator::saveToPGM()");
 
     if (m_settings.bDryRun)
         return;
@@ -137,9 +137,9 @@ void pengen::Generator::saveToPGM() const
     }
 }
 
-void pengen::Generator::cacheFrequencyAndAmplitude()
+void noisegen::Generator::cacheFrequencyAndAmplitude()
 {
-    PENGEN_SCOPED_PROFILER("Generator::cacheFrequencyAndAmplitude()");
+    NOISEGEN_SCOPED_PROFILER("Generator::cacheFrequencyAndAmplitude()");
 
     m_frequencyCache.resize(m_settings.octaves);
     m_amplitudeCache.resize(m_settings.octaves);

--- a/lib/src/Random.cpp
+++ b/lib/src/Random.cpp
@@ -19,5 +19,5 @@
 
 #include "Random.hpp"
 
-std::random_device pengen::Random::s_randomDevice{};
-std::mt19937 pengen::Random::s_generator{s_randomDevice()};
+std::random_device noisegen::Random::s_randomDevice{};
+std::mt19937 noisegen::Random::s_generator{s_randomDevice()};

--- a/lib/src/ScopedProfiler.cpp
+++ b/lib/src/ScopedProfiler.cpp
@@ -23,11 +23,11 @@
 
 #include "ScopedProfiler.hpp"
 
-pengen::utils::ScopedProfiler::ScopedProfiler(const char *name) noexcept : m_start{Clock::now()}, m_name{name}
+noisegen::utils::ScopedProfiler::ScopedProfiler(const char *name) noexcept : m_start{Clock::now()}, m_name{name}
 {
 }
 
-pengen::utils::ScopedProfiler::~ScopedProfiler()
+noisegen::utils::ScopedProfiler::~ScopedProfiler()
 {
     const auto end = Clock::now();
     const DurationSeconds durationSeconds = end - m_start;

--- a/lib/src/Settings.cpp
+++ b/lib/src/Settings.cpp
@@ -21,7 +21,7 @@
 
 #include "Settings.hpp"
 
-std::ostream &pengen::operator<<(std::ostream &os, const pengen::Settings &settings)
+std::ostream &noisegen::operator<<(std::ostream &os, const noisegen::Settings &settings)
 {
     os << "width: " << settings.width << " height: " << settings.height << " octaves: " << settings.octaves
        << " persistence: " << settings.persistence << " count: " << settings.count
@@ -30,7 +30,7 @@ std::ostream &pengen::operator<<(std::ostream &os, const pengen::Settings &setti
     return os;
 }
 
-std::string pengen::Settings::toString() const
+std::string noisegen::Settings::toString() const
 {
     std::ostringstream oss{};
 


### PR DESCRIPTION
Was `perlin-noise-generator`, a bit too long.
Now it feels better!